### PR TITLE
Add configuration without chat filters

### DIFF
--- a/src/main/scala/konstructs/universe.scala
+++ b/src/main/scala/konstructs/universe.scala
@@ -69,6 +69,14 @@ object UniverseActor {
   = Props(classOf[UniverseActor], name, jsonStorage, binaryStorage, chatFilters, blockListeners)
 
   @PluginConstructor
+  def propsWithOnlyBlocks(name: String, notUsed: ActorRef,
+    @Config(key = "binary-storage") binaryStorage: ActorRef,
+    @Config(key = "json-storage") jsonStorage: ActorRef,
+    @ListConfig(key = "block-listeners", elementType = classOf[ActorRef]) blockListeners: Seq[ActorRef]
+  ): Props
+  = Props(classOf[UniverseActor], name, jsonStorage, binaryStorage, Seq(), blockListeners)
+
+  @PluginConstructor
   def props(name: String, notUsed: ActorRef,
     @Config(key = "binary-storage") binaryStorage: ActorRef,
     @Config(key = "json-storage") jsonStorage: ActorRef,


### PR DESCRIPTION
Fixes bug that universe defaulted to a configuration without block-listeners if the chat-listeners was not proivded.