### PR TITLE
Add fullName to BlockTypeId

### DIFF
--- a/src/main/scala/konstructs/api/api.scala
+++ b/src/main/scala/konstructs/api/api.scala
@@ -20,7 +20,9 @@ object BlockType {
   val ShapePlant = "plant"
 }
 
-case class BlockTypeId(namespace: String, name: String)
+case class BlockTypeId(namespace: String, name: String) {
+  def fullName() : String = s"$namespace/$name"
+}
 
 object BlockTypeId {
   val Vacuum = BlockTypeId("org/konstructs", "vacuum")


### PR DESCRIPTION
It got annoying to type

```
if (foo.namespace().equals("org/konstructs") && foo.name().equals("dirt")) { .. }
```

so this adds:
```
if (foo.fullName().equals("org/konstructs/dirt")) { .. }
```