### PR TITLE
Fix boxquery

### DIFF
--- a/src/main/java/konstructs/plugin/KonstructsActor.java
+++ b/src/main/java/konstructs/plugin/KonstructsActor.java
@@ -102,7 +102,7 @@ public abstract class KonstructsActor extends UntypedActorWithStash {
      *  @param until End corner of box (this block is excluded)
      */
     public void boxQuery(Box box) {
-        universe.tell(box, getSelf());
+        universe.tell(new BoxQuery(box), getSelf());
     }
 
     /**


### PR DESCRIPTION
Found a typo in boxQuery from KonstructsActor, it sent a `Box` to universe.