### PR TITLE
Fix empty belt slot bug in tool sack

### DIFF
--- a/src/main/scala/konstructs/plugin/toolsack/sack.scala
+++ b/src/main/scala/konstructs/plugin/toolsack/sack.scala
@@ -11,7 +11,7 @@ class ToolSackActor(universe: ActorRef) extends Actor {
   def receive = {
     case i: InteractTertiaryFilter =>
       i.message match {
-        case InteractTertiary(sender, _, _, block) if block.getId != null && block.getType == BlockId =>
+        case InteractTertiary(sender, _, _, block) if block != null && block.getId != null && block.getType == BlockId =>
           sender ! ReceiveStack(Stack.createFromBlock(i.message.block))
           context.actorOf(KonstructingViewActor.props(sender, universe, block.getId,
             SackView, KonstructingView, ResultView))


### PR DESCRIPTION
- When an empty slot is used with the tertiary action the tool sack
  actor crashes
- This is not very severe as the actor is immediately restarted for
  the next message and has no state