### PR TITLE
Set PickAxe to default at 4.0 damage to stone

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -239,7 +239,7 @@ konstructs {
       }
       org/konstructs/class/PickAxe {
         damage-multipliers {
-          org/konstructs/class/Stone = 2.0
+          org/konstructs/class/Stone = 4.0
         }
       }
     }


### PR DESCRIPTION
@nsg Since stone is so hard, I think this multiplier makes the time it takes to break one more reasonable, There is still plenty of room to add faster pick axes on top of this.