### PR TITLE
Keep id of block until destroyed

### DIFF
--- a/src/main/scala/konstructs/shard/ShardActor.scala
+++ b/src/main/scala/konstructs/shard/ShardActor.scala
@@ -232,9 +232,9 @@ class ShardActor(db: ActorRef,
       } else {
         dealing.withHealth(dealingHealth)
       }
-      val id = positionMapping.remove(str(position))
-      val oldBlock = old.block(id, receivingTypeId)
       if (receivingHealth.isDestroyed()) {
+        val id = positionMapping.remove(str(position))
+        val oldBlock = old.block(id, receivingTypeId)
         if (id != null)
           positionMappingDirty = true
         val block = if (receivingType.getDestroyedAs() == BlockTypeId.SELF) {


### PR DESCRIPTION
- This fixes the bug that removed the id from blocks that were being
  damaged, but not yet destroyed