### PR TITLE
test: Check for current year in LICENSE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,11 @@ notifications:
     on_failure: always  # options: [always|never|change] default: always
     on_start: always    # options: [always|never|change] default: always
 
-script:
-  - "sbt scalafmtTest || ( sbt scalafmt; git diff --exit-code ) "
+before_script:
+  - "sbt scalafmtTest || ( sbt scalafmt; git diff --exit-code )"
   - "grep $(date +%Y) LICENSE"
+
+script:
   - sbt test assembly doc
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ notifications:
 
 script:
   - "sbt scalafmtTest || ( sbt scalafmt; git diff --exit-code ) "
+  - "grep $(date +%Y) LICENSE"
   - sbt test assembly doc
 
 deploy:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2016 Petter Arvidsson and Stefan Berggren
+Copyright (c) 2015-2017 Petter Arvidsson and Stefan Berggren
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
... on second thought I'm not sure if I like this :)

PRO
* We will never forget to update LICENSE, the first commit in 2018 will have a updated LICENSE

CON
* If the first commit in 2018 is some random person, do we really like to enforce this?

A possible version would be to enforce this only on master but then master would probably fail once on the first commit on 2018, with a commit soon after fixing it.

What is the lesser evil here @petterarvidsson, what do you think?